### PR TITLE
reworded documentation section for clarity

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Django Port of Hydrus
 Documentation
 -------------
 
-The full documentation is at https://django-rest-hydra.readthedocs.io.
+Full documentation can be found at https://django-rest-hydra.readthedocs.io.
 
 Quickstart
 ----------


### PR DESCRIPTION
"The full documentation is at" -> "Full documentation can be found at"